### PR TITLE
Refactoring

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -71,7 +71,7 @@ var QueryType = new GraphQLObjectType({
 })
 
 var MutationAdd = {
-  type: new GraphQLList(TodoType),
+  type: TodoType,
   description: 'Add a Todo',
   args: {
     title: {
@@ -88,14 +88,14 @@ var MutationAdd = {
     return new Promise((resolve, reject) => {
       newTodo.save(function (err) {
         if (err) reject(err)
-        else promiseListAll().then(resolve, reject)
+        else resolve(newTodo)
       })
     })
   }
 }
 
 var MutationToggle = {
-  type: new GraphQLList(TodoType),
+  type: TodoType,
   description: 'Toggle the todo',
   args: {
     id: {
@@ -112,22 +112,22 @@ var MutationToggle = {
         }
 
         if (!todo) {
-          promiseListAll().then(resolve, reject)
+          reject('Todo NOT found')
           return
+        } else {
+          todo.completed = !todo.completed
+          todo.save((err) => {
+            if (err) reject(err)
+            else resolve(todo)
+          })
         }
-
-        todo.completed = !todo.completed
-        todo.save((err) => {
-          if (err) reject(err)
-          else promiseListAll().then(resolve, reject)
-        })
       })
     })
   }
 }
 
 var MutationDestroy = {
-  type: new GraphQLList(TodoType),
+  type: TodoType,
   description: 'Destroy the todo',
   args: {
     id: {
@@ -138,11 +138,16 @@ var MutationDestroy = {
   resolve: (root, args) => {
     return new Promise((resolve, reject) => {
       TODO.findById(args.id, (err, todo) => {
-        err && reject(err)
-        todo && todo.remove((err) => {
-          if (err) reject(err)
-          else promiseListAll().then(resolve, reject)
-        })
+        if (err) {
+          reject(err)
+        } else if (!todo) {
+          reject('Todo NOT found')
+        } else {
+          todo.remove((err) => {
+            if (err) reject(err)
+            else resolve(todo)
+          })
+        }
       })
     })
   }
@@ -186,21 +191,26 @@ var MutationClearCompleted = {
   description: 'Clear completed',
   resolve: () => {
     return new Promise((resolve, reject) => {
-      TODO.remove({
-        completed: true
-      }, (err) => {
-        err && reject(err)
-        TODO.find((err, todos) => {
-          if (err) reject(err)
-          else resolve(todos)
-        })
+      TODO.find({completed: true}, (err, todos) => {
+        if (err) {
+          reject(err)
+        } else {
+          TODO.remove({
+            _id: {
+              $in: todos.map((todo) => todo._id)
+            }
+          }, (err) => {
+            if (err) reject(err)
+            else resolve(todos)
+          })
+        }
       })
     })
   }
 }
 
 var MutationSave = {
-  type: new GraphQLList(TodoType),
+  type: TodoType,
   description: 'Edit a todo',
   args: {
     id: {
@@ -221,14 +231,14 @@ var MutationSave = {
         }
 
         if (!todo) {
-          promiseListAll().then(resolve, reject)
+          reject('Todo NOT found')
           return
         }
 
         todo.title = args.title
         todo.save((err) => {
           if (err) reject(err)
-          else promiseListAll().then(resolve, reject)
+          else resolve(todo)
         })
       })
     })

--- a/schema.js
+++ b/schema.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose')
 var graphql = require('graphql')
 var GraphQLObjectType = graphql.GraphQLObjectType
 var GraphQLBoolean = graphql.GraphQLBoolean
+var GraphQLID = graphql.GraphQLID
 var GraphQLString = graphql.GraphQLString
 var GraphQLList = graphql.GraphQLList
 var GraphQLNonNull = graphql.GraphQLNonNull
@@ -9,7 +10,7 @@ var GraphQLSchema = graphql.GraphQLSchema
 
 // Mongoose Schema definition
 var TODO = mongoose.model('Todo', {
-  id: String,
+  id: mongoose.Schema.Types.ObjectId,
   title: String,
   completed: Boolean
 })
@@ -34,7 +35,7 @@ var TodoType = new GraphQLObjectType({
   name: 'todo',
   fields: () => ({
     id: {
-      type: GraphQLString,
+      type: GraphQLID,
       description: 'Todo id'
     },
     title: {


### PR DESCRIPTION
Two things here (_see the git history for futher details_):
- I changed the return of mutations. Once changing a single todo, it is not returning a list anymore. For instance, if you add a todo, it will return only the todo added.
- I changed the ID type of Graphql, as well as the id type of the mongo schema.

``` js
// CHANGED: id type of the mongo schema
var TODO = mongoose.model('Todo', {
  id: mongoose.Schema.Types.ObjectId,
  title: String,
  completed: Boolean
})

// ...
// CHANGED: id type of the graphql object
var TodoType = new GraphQLObjectType({
  name: 'todo',
  fields: () => ({
    id: {
      type: GraphQLID,
      description: 'Todo id'
    },
    title: {
      type: GraphQLString,
      description: 'Task title'
    },
    completed: {
      type: GraphQLBoolean,
      description: 'Flag to mark if the task is completed'
    }
  })
})
```
